### PR TITLE
work around nimble being broken

### DIFF
--- a/gram.nimble
+++ b/gram.nimble
@@ -5,6 +5,7 @@ license = "MIT"
 
 requires "https://github.com/disruptek/skiplists >= 0.5.1 & < 1.0.0"
 requires "https://github.com/disruptek/grok < 1.0.0"
+requires "https://github.com/haxscramper/hmisc >= 0.11.4"
 requires "https://github.com/haxscramper/hasts < 1.0.0"
 
 when not defined(release):

--- a/gram.nimble
+++ b/gram.nimble
@@ -5,7 +5,7 @@ license = "MIT"
 
 requires "https://github.com/disruptek/skiplists >= 0.5.1 & < 1.0.0"
 requires "https://github.com/disruptek/grok < 1.0.0"
-requires "https://github.com/haxscramper/hmisc >= 0.11.4"
+requires "https://github.com/haxscramper/hmisc >= 0.11.4"  # nimble 🤬
 requires "https://github.com/haxscramper/hasts < 1.0.0"
 
 when not defined(release):


### PR DESCRIPTION
`hmisc` requires 0.11.4, I assume, and Nimble decides that `hasts` gets 0.11.3 for some reason.  I mean, who really knows, anymore...